### PR TITLE
Use --get to get github username and token

### DIFF
--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -752,13 +752,13 @@ endfunction
 function! gist#Gist(count, line1, line2, ...)
   redraw
   if !exists('g:github_user')
-    let g:github_user = substitute(system('git config --global github.user'), "\n", '', '')
+    let g:github_user = substitute(system('git config --get github.user'), "\n", '', '')
     if strlen(g:github_user) == 0
       let g:github_user = $GITHUB_USER
     end
   endif
   if !exists('g:github_token')
-    let g:github_token = substitute(system('git config --global github.token'), "\n", '', '')
+    let g:github_token = substitute(system('git config --get github.token'), "\n", '', '')
     if strlen(g:github_token) == 0
       let g:github_token = $GITHUB_TOKEN
     end


### PR DESCRIPTION
Hey,

By using --get people can take advantage of git's recent includes functionality: https://github.com/git/git/commit/9b25a0b52e09400719366f0a33d0d0da98bbf7b0

This will allow people to not have to either store their github credentials in their .gitconfig file or add them in each time they clone their dotfiles. --global will only get keys in their global config files but not keys in files they've included.

It also degrades gracefully and functions just as well for people using older git versions.

Thanks
