### PR TITLE
Use password once to get OAuth token, and forget

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -190,31 +190,14 @@ If you want to uninstall gist.vim, remember to also remove `~/.gist-vim`.
 
 ## Setup:
 
-This plugin uses github API v3. Setting value is stored in `~/.gist.vim`.
+This plugin uses github API v3. Setting value is stored in `~/.gist-vim`.
 gist-vim have two ways to access APIs.
 
-### Basic Auth
+First, you need to set your Github username in global git config:
 
-Require github user ID and password. This is easy but not secure.
+    $ git config --global github.user Username
 
-### OAuth2
-
-1. Register your application.
-
-Note that you must set `Callback URL` as same as following.
-
-https://github.com/settings/applications/new
-
-fill like following
-
-![](http://mattn.github.com/gist-vim/static/image/setting1.png)
-
-2. Start `:Gist -l`
-
-You'll see some prompts. fill ClientID/CilentSecret. Then you can see browser show up.
-
-![](http://mattn.github.com/gist-vim/static/image/setting2.png)
-
-This is a PIN code.
-
-Copy this value and paste to prompt `PIN:`.
+Then, gist.vim will ask for your password to create an authorization when you
+first use it.  The password is not stored and only the OAuth access token will
+be kept for later use.  You can revoke the token at any time from the list of
+["Authorized applications" on Github's "Account Settings" page](https://github.com/settings/applications).

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -207,46 +207,27 @@ SETUP                                                       *gist-vim-setup*
 This plugin uses github API v3. Setting value is stored in `~/.gist.vim`.
 gist-vim have two ways to access APIs.
 
-|BasicAuth|
-
-  Require github user ID and password. This is easy but not secure.
-  You need to set global git config:
+First, you need to set your Github username in global git config:
 >
     $ git config --global github.user Username
 <
-  If you want to use password written in ~/.gitconfig like below:
+Then, gist.vim will ask for your password to create an authorization when you
+first use it.  The password is not stored and only the OAuth access token will
+be kept for later use.  You can revoke the token at any time from the list of
+"Authorized applications" on Github's "Account Settings" page.
+(https://github.com/settings/applications)
+
+If you happen to have your password already written in ~/.gitconfig like
+below:
 >
     [github]
         password = xxxxx
 <
-  Add following into your ~/.vimrc
+Then, add following into your ~/.vimrc
 >
     let g:gist_use_password_in_gitconfig = 1
 <
-|OAuth2|
-
- 1. Register your application.
-
-   Note that you must set `Callback URL` as same as following.
-
-   https://github.com/settings/applications/new
-
-   fill like following
-
-   Callback URL should be http://mattn.github.com/gist-vim
-   If you don't want to point this site, use URL parameter 'code' as PIN.
-
-  2. If you haven't already set up your github user in .gitconfig:
->
-    $ git config --global github.user Username
-<
-
-  3. Start `:Gist -l`
-
-    You'll see some prompts. fill ClientID/CilentSecret. Then you can see
-    browser show up.
-    If you set Callback URL above, you can see PIN code.
-    Copy this value and paste to prompt `PIN:`.
+This is not secure at all, so strongly discouraged.
 
 ==============================================================================
 THANKS                                                     *gist-vim-thanks*
@@ -265,5 +246,6 @@ THANKS                                                     *gist-vim-thanks*
   steve
   tyru
   Will Gray
+  netj
 
  vim:tw=78:ts=8:ft=help:norl:


### PR DESCRIPTION
Github provides a simple way to create an OAuth token using Basic Auth:
http://developer.github.com/v3/oauth/#create-a-new-authorization

This enables Gist.vim to ask users' password once on first use, and
store only the obtained token for later.  User can easily revoke the
token and create a new one at anytime, so this is much more secure.
Forcing them to create their own Github application and exchanging
client ID and secrets is totally a nonsense given this simple way to get
the same token. :)
