### PR TITLE
Add two-factor authentication setup instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -211,6 +211,11 @@ Now restart Vim and run `:BundleInstall`.
 
 ## Setup:
 
+### Basic Authentication
+
+If you don't have two-factor authentication enabled, follow the
+instructions in this section.
+
 This plugin uses GitHub API v3. Setting value is stored in `~/.gist-vim`.
 gist-vim have two ways to access APIs.
 
@@ -221,4 +226,23 @@ First, you need to set your Github username in global git config:
 Then, gist.vim will ask for your password to create an authorization when you
 first use it.  The password is not stored and only the OAuth access token will
 be kept for later use.  You can revoke the token at any time from the list of
-["Authorized applications" on GitHub's "Account Settings" page](https://github.com/settings/applications).
+["Authorized applications" on GitHub's "Account Settings" page][uas].
+
+### Two-factor Authentication
+
+If you use two-factor authentication, you will need to set things up
+slightly differently. Luckily, it's not hard at all.
+
+First, go to your [user application settings page][uas] on GitHub. In the
+section 'Personal access tokens', click the button to 'Generate new
+token'. Name the token something easy to remember, like 'gist-vim', and
+then copy the token itself. Finally paste the token you just made into
+`~/.gist-vim`. (Create that file, if it doesn't already exist.) The final
+result should look like this:
+
+    token <paste-your-token-here>
+
+Done! You can revoke this token at any time from your [application
+settings][uas].
+
+[uas]: https://github.com/settings/applications


### PR DESCRIPTION
As per #141, this change adds instructions for setting up
gist-vim with two-factor authentication to the README.

Thanks for gist-vim.
