### PR TITLE
Fixes trailing slash problem

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -144,7 +144,7 @@ If you want to manipulate multiple files in a gist:
 
 If you want to use on GitHub Enterprise:
 
-    let g:github_api_url = 'http://your-github-enterprise-domain/api/v3'
+    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3'
 
 You need to either set global git config:
 

--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -1,7 +1,7 @@
 "=============================================================================
 " File: gist.vim
 " Author: Yasuhiro Matsumoto <mattn.jp@gmail.com>
-" Last Change: 13-Apr-2014.
+" Last Change: 15-Apr-2014.
 " Version: 7.1
 " WebPage: http://github.com/mattn/gist-vim
 " License: BSD
@@ -34,10 +34,10 @@ if !exists('g:github_user')
   end
 endif
 
-if !exists('g:github_api_url')
-  let g:github_api_url = substitute(s:system('git config --get github.apiurl'), "\n", '', '')
-  if strlen(g:github_api_url) == 0
-    let g:github_api_url = 'https://api.github.com'
+if !exists('g:gist_api_url')
+  let g:gist_api_url = substitute(s:system('git config --get github.apiurl'), "\n", '', '')
+  if strlen(g:gist_api_url) == 0
+    let g:gist_api_url = 'https://api.github.com/'
   end
 endif
 
@@ -117,13 +117,13 @@ endfunction
 let s:bufprefix = 'gist' . (has('unix') ? ':' : '_')
 function! s:GistList(gistls, page)
   if a:gistls == '-all'
-    let url = g:github_api_url.'/gists/public'
+    let url = g:gist_api_url.'gists/public'
   elseif get(g:, 'gist_show_privates', 0) && a:gistls == 'starred'
-    let url = g:github_api_url.'/gists/starred'
+    let url = g:gist_api_url.'gists/starred'
   elseif get(g:, 'gist_show_privates') && a:gistls == 'mine'
-    let url = g:github_api_url.'/gists'
+    let url = g:gist_api_url.'gists'
   else
-    let url = g:github_api_url.'/users/'.a:gistls.'/gists'
+    let url = g:gist_api_url.'users/'.a:gistls.'/gists'
   endif
   let winnum = bufwinnr(bufnr(s:bufprefix.a:gistls))
   if winnum != -1
@@ -199,13 +199,13 @@ endfunction
 function! gist#list(user, ...)
   let page = get(a:000, 0, 0)
   if a:user == '-all'
-    let url = g:github_api_url.'/gists/public'
+    let url = g:gist_api_url.'gists/public'
   elseif get(g:, 'gist_show_privates', 0) && a:user == 'starred'
-    let url = g:github_api_url.'/gists/starred'
+    let url = g:gist_api_url.'gists/starred'
   elseif get(g:, 'gist_show_privates') && a:user == 'mine'
-    let url = g:github_api_url.'/gists'
+    let url = g:gist_api_url.'gists'
   else
-    let url = g:github_api_url.'/users/'.a:user.'/gists'
+    let url = g:gist_api_url.'users/'.a:user.'/gists'
   endif
 
   let auth = s:GistGetAuthHeader()
@@ -221,7 +221,7 @@ function! s:GistGetFileName(gistid)
   if len(auth) == 0
     return ''
   endif
-  let res = webapi#http#get(g:github_api_url.'/gists/'.a:gistid, '', { "Authorization": auth })
+  let res = webapi#http#get(g:gist_api_url.'gists/'.a:gistid, '', { "Authorization": auth })
   let gist = webapi#json#decode(res.content)
   if has_key(gist, 'files')
     return sort(keys(gist.files))[0]
@@ -234,7 +234,7 @@ function! s:GistDetectFiletype(gistid)
   if len(auth) == 0
     return ''
   endif
-  let res = webapi#http#get(g:github_api_url.'/gists/'.a:gistid, '', { "Authorization": auth })
+  let res = webapi#http#get(g:gist_api_url.'gists/'.a:gistid, '', { "Authorization": auth })
   let gist = webapi#json#decode(res.content)
   let filename = sort(keys(gist.files))[0]
   let ext = fnamemodify(filename, ':e')
@@ -262,7 +262,7 @@ endfunction
 
 function! s:GistGet(gistid, clipboard)
   redraw | echon 'Getting gist... '
-  let res = webapi#http#get(g:github_api_url.'/gists/'.a:gistid, '', { "Authorization": s:GistGetAuthHeader() })
+  let res = webapi#http#get(g:gist_api_url.'gists/'.a:gistid, '', { "Authorization": s:GistGetAuthHeader() })
   if res.status =~ '^2'
     try
       let gist = webapi#json#decode(res.content)
@@ -393,7 +393,7 @@ function! s:GistUpdate(content, gistid, gistnm, desc)
   if a:desc != ' '
     let gist["description"] = a:desc
   else
-    let res = webapi#http#get(g:github_api_url.'/gists/'.a:gistid, '', { "Authorization": auth })
+    let res = webapi#http#get(g:gist_api_url.'gists/'.a:gistid, '', { "Authorization": auth })
     if res.status =~ '^2'
       let old_gist = webapi#json#decode(res.content)
       let gist["description"] = old_gist.description
@@ -403,7 +403,7 @@ function! s:GistUpdate(content, gistid, gistnm, desc)
   let gist.files[filename] = { "content": a:content, "filename": filename }
 
   redraw | echon 'Updating gist... '
-  let res = webapi#http#post(g:github_api_url.'/gists/' . a:gistid,
+  let res = webapi#http#post(g:gist_api_url.'gists/' . a:gistid,
   \ webapi#json#encode(gist), {
   \   "Authorization": auth,
   \   "Content-Type": "application/json",
@@ -430,7 +430,7 @@ function! s:GistDelete(gistid)
   endif
 
   redraw | echon 'Deleting gist... '
-  let res = webapi#http#post(g:github_api_url.'/gists/'.a:gistid, '', {
+  let res = webapi#http#post(g:gist_api_url.'gists/'.a:gistid, '', {
   \   "Authorization": auth,
   \   "Content-Type": "application/json",
   \}, 'DELETE')
@@ -502,7 +502,7 @@ function! s:GistPost(content, private, desc, anonymous)
   endif
 
   redraw | echon 'Posting it to gist... '
-  let res = webapi#http#post(g:github_api_url.'/gists', webapi#json#encode(gist), header)
+  let res = webapi#http#post(g:gist_api_url.'gists', webapi#json#encode(gist), header)
   if res.status =~ '^2'
     let obj = webapi#json#decode(res.content)
     let loc = obj["html_url"]
@@ -558,7 +558,7 @@ function! s:GistPostBuffers(private, desc, anonymous)
   endif
 
   redraw | echon 'Posting it to gist... '
-  let res = webapi#http#post(g:github_api_url.'/gists', webapi#json#encode(gist), header)
+  let res = webapi#http#post(g:gist_api_url.'gists', webapi#json#encode(gist), header)
   if res.status =~ '^2'
     let obj = webapi#json#decode(res.content)
     let loc = obj["html_url"]
@@ -612,10 +612,10 @@ function! gist#Gist(count, line1, line2, ...)
     if arg =~ '^\(-h\|--help\)$\C'
       help :Gist
       return
-    elseif arg =~ '^\(-g\|--git\)$\C' && gistidbuf != '' && g:github_api_url == 'https://api.github.com' && has_key(b:, 'gist') && has_key(b:gist, 'id')
+    elseif arg =~ '^\(-g\|--git\)$\C' && gistidbuf != '' && g:gist_api_url == 'https://api.github.com/' && has_key(b:, 'gist') && has_key(b:gist, 'id')
       echo printf('git clone git@github.com:%s', b:gist['id'])
       return
-    elseif arg =~ '^\(-G\|--gitclone\)$\C' && gistidbuf != '' && g:github_api_url == 'https://api.github.com' && has_key(b:, 'gist') && has_key(b:gist, 'id')
+    elseif arg =~ '^\(-G\|--gitclone\)$\C' && gistidbuf != '' && g:gist_api_url == 'https://api.github.com/' && has_key(b:, 'gist') && has_key(b:gist, 'id')
       exe '!' printf('git clone git@github.com:%s', b:gist['id'])
       return
     elseif arg =~ '^\(-la\|--listall\)$\C'
@@ -640,7 +640,7 @@ function! gist#Gist(count, line1, line2, ...)
       let gistdesc = ''
     elseif arg =~ '^\(-c\|--clipboard\)$\C'
       let clipboard = 1
-    elseif arg =~ '^--rawurl$\C' && gistidbuf != '' && g:github_api_url == 'https://api.github.com'
+    elseif arg =~ '^--rawurl$\C' && gistidbuf != '' && g:gist_api_url == 'https://api.github.com/'
       let gistid = gistidbuf
       echo 'https://gist.github.com/raw/'.gistid
       return
@@ -656,7 +656,7 @@ function! gist#Gist(count, line1, line2, ...)
         echohl ErrorMsg | echomsg v:errmsg | echohl None
       else
         let gistid = gistidbuf
-        let res = webapi#http#post(g:github_api_url.'/gists/'.gistid.'/star', '', { "Authorization": auth }, 'PUT')
+        let res = webapi#http#post(g:gist_api_url.'gists/'.gistid.'/star', '', { "Authorization": auth }, 'PUT')
         if res.status =~ '^2'
           echomsg "Stared" gistid
         else
@@ -670,7 +670,7 @@ function! gist#Gist(count, line1, line2, ...)
         echohl ErrorMsg | echomsg v:errmsg | echohl None
       else
         let gistid = gistidbuf
-        let res = webapi#http#post(g:github_api_url.'/gists/'.gistid.'/star', '', { "Authorization": auth }, 'DELETE')
+        let res = webapi#http#post(g:gist_api_url.'gists/'.gistid.'/star', '', { "Authorization": auth }, 'DELETE')
         if res.status =~ '^2'
           echomsg "Unstared" gistid
         else
@@ -685,7 +685,7 @@ function! gist#Gist(count, line1, line2, ...)
         return
       else
         let gistid = gistidbuf
-        let res = webapi#http#post(g:github_api_url.'/gists/'.gistid.'/fork', '', { "Authorization": auth })
+        let res = webapi#http#post(g:gist_api_url.'gists/'.gistid.'/fork', '', { "Authorization": auth })
         if res.status =~ '^2'
           let obj = webapi#json#decode(res.content)
           let gistid = obj["id"]
@@ -807,7 +807,7 @@ function! s:GistGetAuthHeader()
     return ''
   endif
   let insecureSecret = printf("basic %s", webapi#base64#b64encode(g:github_user.":".password))
-  let res = webapi#http#post(g:github_api_url.'/authorizations', webapi#json#encode({
+  let res = webapi#http#post(g:gist_api_url.'authorizations', webapi#json#encode({
               \  "scopes"   : ["gist"],
               \  "note"     : "Gist.vim on ".hostname(),
               \  "note_url" : "http://www.vim.org/scripts/script.php?script_id=2423"
@@ -822,7 +822,7 @@ function! s:GistGetAuthHeader()
       let v:errmsg = 'Canceled'
       return ''
     endif
-    let res = webapi#http#post(g:github_api_url.'/authorizations', webapi#json#encode({
+    let res = webapi#http#post(g:gist_api_url.'authorizations', webapi#json#encode({
                 \  "scopes"   : ["gist"],
                 \  "note"     : "Gist.vim on ".hostname(),
                 \  "note_url" : "http://www.vim.org/scripts/script.php?script_id=2423"

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -155,7 +155,7 @@ If you want to edit all files for gists containing more than one: >
 
 If you want to use on GitHub Enterprise: >
 
-    let g:github_api_url = 'http://your-github-enterprise-domain/api/v3'
+    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3'
 <
 
 If you want to update a gist, embed >


### PR DESCRIPTION
I made the following changes (see issue #152)
- `github_api_url` is now `gist_api_url`, as `fugitive` uses the same variable name
- `gist_api_url` now has a final trailing slash, which avoid the weird problem of `https://api.github.com//gists`
