### PR TITLE
Fix the usage for GitHub Enterprise

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -144,7 +144,7 @@ If you want to manipulate multiple files in a gist:
 
 If you want to use on GitHub Enterprise:
 
-    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3'
+    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3/'
 
 You need to either set global git config:
 

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -155,7 +155,7 @@ If you want to edit all files for gists containing more than one: >
 
 If you want to use on GitHub Enterprise: >
 
-    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3'
+    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3/'
 <
 
 If you want to update a gist, embed >


### PR DESCRIPTION
You need to include a trailing slash into the `gist_api_url` setting If you want to have the integration with GitHub Enterprise API.
