### PR TITLE
Add option to open browser after posting or updating gist

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -95,6 +95,10 @@ For the latest version please see https://github.com/mattn/gist-vim.
 
         :Gist -ls
 
+- Open the gist on browser after you post or update it.
+
+        :Gist -b
+
 ## Tips:
 
 If you set g:gist_clip_command, gist.vim will copy the gist code with option

--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -617,6 +617,7 @@ function! gist#Gist(count, line1, line2, ...) abort
   let deletepost = 0
   let editpost = 0
   let anonymous = 0
+  let openbrowser = 0
   let listmx = '^\%(-l\|--list\)\s*\([^\s]\+\)\?$'
   let bufnamemx = '^' . s:bufprefix .'\(\zs[0-9a-f]\+\ze\|\zs[0-9a-f]\+\ze[/\\].*\)$'
   if bufname =~ bufnamemx
@@ -714,6 +715,8 @@ function! gist#Gist(count, line1, line2, ...) abort
           return
         endif
       endif
+    elseif arg =~ '^\(-b\|--browser\)$\C'
+      let openbrowser = 1
     elseif arg !~ '^-' && len(gistnm) == 0
       if gistdesc != ' '
         let gistdesc = matchstr(arg, '^\s*\zs.*\ze\s*$')
@@ -779,7 +782,7 @@ function! gist#Gist(count, line1, line2, ...) abort
       endif
     endif
     if len(url) > 0
-      if get(g:, 'gist_open_browser_after_post', 0) == 1
+      if get(g:, 'gist_open_browser_after_post', 0) == 1 || openbrowser
         call s:open_browser(url)
       endif
       let gist_put_url_to_clipboard_after_post = get(g:, 'gist_put_url_to_clipboard_after_post', 1)

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -106,6 +106,10 @@ USAGE                                                 *:Gist* *gist-vim-usage*
 >
     :Gist -ls
 <
+- Open the gist on browser after you post or update it.
+>
+    :Gist -b
+<
 ==============================================================================
 TIPS                                                           *gist-vim-tips*
 

--- a/plugin/gist.vim
+++ b/plugin/gist.vim
@@ -12,9 +12,9 @@ endif
 let g:loaded_gist_vim = 1
 
 function! s:CompleteArgs(arg_lead,cmdline,cursor_pos)
-    return ["-p", "-P", "-a", "-m", "-e", "-s", "-d", "+1", "-1", "-f", "-c", "-l", "-la", "-ls",
+    return ["-p", "-P", "-a", "-m", "-e", "-s", "-d", "+1", "-1", "-f", "-c", "-l", "-la", "-ls", "-b",
                 \ "--listall", "--liststar", "--list", "--multibuffer", "--private", "--public", "--anonymous", "--description", "--clipboard",
-                \ "--rawurl", "--delete", "--edit", "--star", "--unstar", "--fork"
+                \ "--rawurl", "--delete", "--edit", "--star", "--unstar", "--fork", "--browser"
                 \ ]
 endfunction
 


### PR DESCRIPTION
Users may not always want to open the browser every time they post/update gist. With this option (`-b` or `--browser`), they can choose to open the browser when they want.
