### PR TITLE
Correct the github enterprise api url variable name in the README

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -152,7 +152,7 @@ If you want to manipulate multiple files in a gist:
 
 If you want to use on GitHub Enterprise:
 
-    let g:gist_api_url = 'http://your-github-enterprise-domain/api/v3'
+    let g:github_api_url = 'http://your-github-enterprise-domain/api/v3'
 
 You need to either set global git config:
 


### PR DESCRIPTION
This error cause a little headache for me. I figured out it was simply the wrong variable name after viewing the source. I hope this helps others attempting to integrate the plugin with their own Github Enterprise installation.
