### PR TITLE
Delete the name-duplicating buffer before ceating a gist file buffer

### DIFF
--- a/autoload/gist.vim
+++ b/autoload/gist.vim
@@ -450,6 +450,7 @@ function! s:GistGet(gistid, clipboard) abort
             endif
           endif
           setlocal noswapfile
+          silent! exec 'bdel' s:bufprefix.a:gistid.'/'.fnameescape(filename) 
           silent exec 'noautocmd file' s:bufprefix.a:gistid.'/'.fnameescape(filename)
         endif
         set undolevels=-1


### PR DESCRIPTION
If repeatly opening a same file on the vim-gist, vim-gist gives
the new buffer the same name  as previous buffer, without deleting
the opened buffer first. Then a `file E95` exception is thrown,
and vim-gist will echo error message `Gist contains binary`.

Probably corressponding issue report:
https://github.com/mattn/vim-gist/issues/220