### PR TITLE
Fix token creation URL and file path in docs

### DIFF
--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -275,7 +275,7 @@ rtp:
   - autoload/gist.vim
   - plugin/gist.vim
 
-If you want to uninstall gist.vim, remember to also remove `~/.vim-gist`.
+If you want to uninstall gist.vim, remember to also remove `~/.gist-vim`.
 
 You need to install webapi-vim also:
 
@@ -295,7 +295,7 @@ REQUIREMENTS                                           *vim-gist-requirements*
 ==============================================================================
 SETUP                                                       *vim-gist-setup*
 
-This plugin uses GitHub API v3. The authentication value is stored in `~/.vim-gist`.
+This plugin uses GitHub API v3. The authentication value is stored in `~/.gist-vim`.
 vim-gist provides two ways to authenticate against the GitHub APIs.
 
 First, you need to set your GitHub username in global git config:
@@ -310,9 +310,9 @@ be kept for later use.  You can revoke the token at any time from the list of
 
 If you have two-factor authentication enabled on GitHub, you'll see the message
 "Must specify two-factor authentication OTP code." In this case, you need to
-create a "Personal Access Token" on GitHub's "Account Settings" page
-(https://github.com/settings/applications) and place it in a file
-named ~/.vim-gist like this:
+create a "Personal Access Token" on GitHub's "Developer settings" page
+(https://github.com/settings/tokens) with the gist scope and place it in a file
+named ~/.gist-vim like this:
 >
     token xxxxx
 <
@@ -334,7 +334,7 @@ NOTE: the username is optional if you only send anonymous gists.
 FAQ                                                           *vim-gist-faq*
 
 Q. :Gist returns a Forbidden error
-A. Try deleting ~/.vim-gist and authenticating again.
+A. Try deleting ~/.gist-vim and authenticating again.
 
 ==============================================================================
 THANKS                                                     *vim-gist-thanks*


### PR DESCRIPTION
Similar to #226 though I made these changes before finding the pull
request. In addition to the changes in #226, it updates the URL for
the Personal Access Token to the correct one.