### PR TITLE
Manage per-page limit while listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ For the latest version please see https://github.com/mattn/vim-gist.
 
         :Gist -l mattn
 
+- Specify the number of gists listed:
+
+        :Gist -l -n 100
+
 - List everyone's gists.
 
         :Gist -la
@@ -187,6 +191,10 @@ If you want to use on GitHub Enterprise:
 You need to either set global git config:
 
 	$ git config --global github.user Username
+
+If you want to list more than 30 gists per page (maximum is 100):
+
+    let g:gist_per_page_limit = 100
 
 ## License:
 

--- a/doc/gist-vim.txt
+++ b/doc/gist-vim.txt
@@ -102,6 +102,8 @@ USAGE                                                 *:Gist* *vim-gist-usage*
 
     :Gist -l
     :Gist --list
+    :Gist -l -n 100
+    :Gist --list --per-page 100
 <
 - List gists from user "mattn". >
 
@@ -200,6 +202,10 @@ If you want to open gist with current editing buffers: >
 If you want to open gist list/buffer as vertical split: >
 
     let g:gist_list_vsplit = 1
+
+If you want to list more than 30 gists per page (maximum is 100):
+
+    let g:gist_per_page_limit = 100
 
 If you want to modify filetype for the file on github, or add mapping of
 filetype/file-extension: >

--- a/plugin/gist.vim
+++ b/plugin/gist.vim
@@ -12,12 +12,13 @@ endif
 let g:loaded_gist_vim = 1
 
 function! s:CompleteArgs(arg_lead,cmdline,cursor_pos)
-    return filter(copy(["-p", "-P", "-a", "-m", "-e", "-s", "-d", "+1", "-1", "-f", "-c", "-l", "-la", "-ls", "-b",
+    return filter(copy(["-p", "-P", "-a", "-m", "-e", "-s", "-d", "+1", "-1", "-f", "-c", "-l", "-la", "-ls", "-b", "-n",
                 \ "--listall", "--liststar", "--list", "--multibuffer", "--private", "--public", "--anonymous", "--description", "--clipboard",
-                \ "--rawurl", "--delete", "--edit", "--star", "--unstar", "--fork", "--browser"
+                \ "--rawurl", "--delete", "--edit", "--star", "--unstar", "--fork", "--browser", "--per-page"
                 \ ]), 'stridx(v:val, a:arg_lead)==0')
 endfunction
 
+let g:gist_per_page_limit = get(g:, 'gist_per_page_limit', 30)
 command! -nargs=? -range=% -bang -complete=customlist,s:CompleteArgs Gist :call gist#Gist(<count>, "<bang>", <line1>, <line2>, <f-args>)
 
 " vim:set et:


### PR DESCRIPTION
Control how many gists we're going to get during list commands. Two ways introduced:

1. Global variable `g:gist_per_page_limit` which is 30 by default. Set it to the value that will be used as a default number of gists per page in list commands.
2. Specify the number of gists for any list command explicitly `-n` or `--per-page` option:

```
:Gist -l -n 100
:Gist --list --per-page 100
```

Note that the page limit could not exceed 100 and should be a positive number.

Closes #232